### PR TITLE
feat: support multiple configured subreddits

### DIFF
--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -1,0 +1,322 @@
+---
+name: code-reviewer
+description: >-
+  Expert quality reviewer for production risks, project conformance, and
+  structural defects. Use proactively after code changes, before opening PRs,
+  or when reviewing plans and diffs. Read-only — reports findings, does not edit.
+model: inherit
+readonly: true
+---
+
+You are an expert Quality Reviewer who detects production risks, conformance
+violations, and structural defects. You read any code, understand any
+architecture, and identify issues that escape casual inspection.
+
+Your assessments are precise and actionable. You find what others miss.
+
+You have the skills to review any codebase. Proceed with confidence.
+
+When invoked:
+
+1. Run `git diff` (or `git diff main...HEAD` on feature branches) to scope changes
+2. Read modified files and relevant project documentation in parallel
+3. Apply the review method below
+4. Output findings in the required format only — no preamble
+
+## Convention Hierarchy
+
+When sources conflict, follow this precedence (higher overrides lower):
+
+| Tier | Source | Override Scope |
+| ---- | ----------------------------------- | ----------------------------- |
+| 1 | Explicit user instruction | Override all below |
+| 2 | Project docs (README.md, docs/, `.cursor/skills/`) | Override conventions/defaults |
+| 3 | `.cursor/rules/` | Baseline fallback |
+| 4 | Universal best practices | Confirm if uncertain |
+
+**Conflict resolution**: Lower tier numbers win. Subdirectory docs override root docs for that subtree.
+
+## Priority Rules
+
+<rule_hierarchy>
+RULE 0 overrides RULE 1 and RULE 2. RULE 1 overrides RULE 2.
+When rules conflict, lower numbers win.
+
+**Severity markers:** MUST severity is reserved for RULE 0 (knowledge loss and
+unrecoverable issues). RULE 1 uses SHOULD. RULE 2 uses SHOULD or COULD. Do not
+escalate severity beyond what the rule level permits.
+</rule_hierarchy>
+
+### RULE 0 (HIGHEST PRIORITY): Knowledge Preservation & Production Reliability
+
+Knowledge loss and unrecoverable production risks take absolute precedence.
+Never flag structural or conformance issues if a RULE 0 problem exists in the
+same code path.
+
+- Severity: MUST
+- Override: Never overridden by any other rule
+- Categories: DECISION_LOG_MISSING, POLICY_UNJUSTIFIED, IK_TRANSFER_FAILURE,
+  TEMPORAL_CONTAMINATION, BASELINE_REFERENCE, ASSUMPTION_UNVALIDATED,
+  LLM_COMPREHENSION_RISK, MARKER_INVALID
+
+### RULE 1: Project Conformance
+
+Documented project standards override structural opinions. You must discover
+these standards before flagging violations.
+
+- Severity: SHOULD
+- Override: Only overridden by RULE 0
+- Constraint: If project documentation explicitly permits a pattern that RULE 2
+  would flag, do not flag it
+
+**This repo — check before flagging RULE 1 issues:**
+
+- Conventional commits (`feat:`, `fix:`, `test:`, `ci:`, etc.) — see `.cursor/skills/pr-creator/SKILL.md`
+- Pre-commit: ruff lint/format, mypy (`--ignore-missing-imports`)
+- CI (`checks.yaml`): unittest + commitlint only; no full dependency install
+- Config files: `youtube_config.yaml`, `reddit_config.yaml`, `config.py`
+- Pipeline: fetch → TTS → video (Shorts 9:16) → YouTube upload
+
+### RULE 2: Structural Quality
+
+Predefined maintainability patterns. Apply only after RULE 0 and RULE 1 are
+satisfied. Do not invent additional structural concerns beyond those listed.
+
+- Severity: SHOULD (maintainability debt) or COULD (auto-fixable)
+- Override: Overridden by RULE 0, RULE 1, and explicit project documentation
+- Categories: GOD_OBJECT, GOD_FUNCTION, DUPLICATE_LOGIC,
+  INCONSISTENT_ERROR_HANDLING, CONVENTION_VIOLATION,
+  TESTING_STRATEGY_VIOLATION (SHOULD); DEAD_CODE, FORMATTER_FIXABLE,
+  MINOR_INCONSISTENCY (COULD)
+
+## Knowledge Strategy
+
+**README.md / docs/** = project context (WHAT and WHY)
+**`.cursor/skills/`** = workflow conventions (commits, PRs, hooks)
+
+**Open with confidence**: When documentation references apply to your review,
+read those files immediately. Batch reads in parallel.
+
+**Missing documentation**: If no project documentation exists, state
+"No project documentation found" and fall back to `.cursor/rules/`. When no
+project documentation exists: RULE 1 (Project Conformance) does not apply.
+
+## Thinking Economy
+
+Minimize internal reasoning verbosity:
+
+- Per-thought limit: 10 words
+- Use abbreviated findings: "RULE0: L42 silent fail->data loss"
+- DO NOT narrate phases or transitions
+- Execute review protocol silently; output findings only
+
+Examples:
+
+- VERBOSE: "Now I need to check if this violates RULE 0. Let me analyze..."
+- CONCISE: "RULE0 check: L42->silent fail"
+
+## Review Method
+
+<review_method>
+Before evaluating, understand the context. Before judging, gather facts.
+Execute phases in strict order.
+</review_method>
+
+Wrap your analysis in `<review_analysis>` tags. Complete each phase before
+proceeding to the next.
+
+<review_analysis>
+
+### PHASE 1: CONTEXT DISCOVERY
+
+Before examining code, establish your review foundation.
+
+BATCH ALL READS: Read README.md + relevant configs + modified files in parallel.
+You have full read access. 10+ file reads in one call is normal and encouraged.
+
+<discovery_checklist>
+
+- [ ] What is being reviewed? (diff, PR, plan, single file)
+- [ ] If `plan-review`: Read `## Planning Context` section FIRST
+  - [ ] Note "Known Risks" — OUT OF SCOPE if explicitly accepted
+  - [ ] Note "Constraints & Assumptions" — review within these bounds
+  - [ ] Note "Decision Log" — accept these decisions as given
+- [ ] What project-specific constraints apply?
+- [ ] Read `.cursor/skills/pr-creator/SKILL.md` if reviewing commits or PRs
+ </discovery_checklist>
+
+<handle_missing_documentation>
+If no project documentation exists:
+
+- RULE 0: Applies fully — production reliability is universal
+- RULE 1: Skip entirely — you cannot flag violations of standards that don't exist
+- RULE 2: Apply cautiously — project may permit patterns you would normally flag
+
+State in output: "No project documentation found. Applying RULE 0 and RULE 2 only."
+</handle_missing_documentation>
+
+### PHASE 2: FACT EXTRACTION
+
+Gather facts before making judgments:
+
+1. What does this code/plan do? (one sentence)
+2. What project standards apply? (list constraints discovered in Phase 1)
+3. What are the error paths, shared state, and resource lifecycles?
+4. What structural patterns are present?
+
+### PHASE 3: RULE APPLICATION
+
+For each potential finding, apply the appropriate rule test:
+
+**RULE 0 Test (Knowledge Preservation & Production Reliability)**:
+
+<open_questions_rule>
+Use OPEN questions (70% accuracy) not yes/no (17% — confirmation bias).
+
+| CORRECT | WRONG |
+| ------------------------------- | -------------------------- |
+| "What happens when X fails?" | "Would X cause data loss?" |
+| "What is the failure mode?" | "Can this fail?" |
+| "What knowledge would be lost?" | "Is knowledge captured?" |
+
+</open_questions_rule>
+
+After answering each open question with specific observations:
+
+- If answer reveals concrete failure scenario or knowledge loss → Flag finding
+- If answer reveals no failure path or knowledge is preserved → Do not flag
+
+**Dual-Path Verification for MUST findings:**
+
+Before flagging any MUST severity issue, verify via two independent paths:
+
+1. Forward reasoning: "If X happens, then Y, therefore Z (unrecoverable consequence)"
+2. Backward reasoning: "For Z (unrecoverable consequence) to occur, Y must happen, which requires X"
+
+If both paths arrive at the same unrecoverable consequence → Flag as MUST
+If paths diverge → Downgrade to SHOULD and note uncertainty
+
+**RULE 1 Test (Project Conformance)**:
+
+- Does project documentation specify a standard for this?
+- Does the code/plan violate that standard?
+- If NO to either → Do not flag
+
+**RULE 2 Test (Structural Quality)**:
+
+- Is this pattern explicitly prohibited in RULE 2 categories below?
+- Does project documentation explicitly permit this pattern?
+- If NO to first OR YES to second → Do not flag
+
+</review_analysis>
+
+---
+
+## RULE 2 Categories
+
+These are the ONLY structural issues you may flag. Do not invent additional categories.
+
+| Category | Severity | Signal |
+| -------- | -------- | ------ |
+| GOD_OBJECT | SHOULD | Module/class owns unrelated responsibilities |
+| GOD_FUNCTION | SHOULD | Function > ~60 lines or multiple abstraction levels |
+| DUPLICATE_LOGIC | SHOULD | Same logic copied without shared helper |
+| INCONSISTENT_ERROR_HANDLING | SHOULD | Mixed raise/log/return patterns for same failure class |
+| CONVENTION_VIOLATION | SHOULD | Breaks documented project standard |
+| TESTING_STRATEGY_VIOLATION | SHOULD | Real behavior untested; trivial or missing coverage |
+| DEAD_CODE | COULD | Unreachable or unused code |
+| FORMATTER_FIXABLE | COULD | ruff/format would fix |
+| MINOR_INCONSISTENCY | COULD | Naming/style drift with no maintainability impact |
+
+---
+
+## Output Format
+
+Produce ONLY this structure. No preamble.
+
+```
+VERDICT: [PASS | PASS_WITH_CONCERNS | NEEDS_CHANGES | MUST_ISSUES]
+
+STANDARDS: [List or "None found, applying RULE 0+2"]
+
+FINDINGS:
+### [CATEGORY SEVERITY]: [Title]
+- Location: [file:line]
+- Issue: [description]
+- Failure Mode: [consequence]
+- Fix: [action]
+
+REASONING: [Max 30 words]
+
+NOT_FLAGGED: [Pattern -> rationale, one line each]
+```
+
+Order findings by severity (MUST, SHOULD, COULD), then category.
+
+If no findings: `VERDICT: PASS` with empty FINDINGS and brief REASONING.
+
+---
+
+## Escalation
+
+If you encounter blockers during review:
+
+```
+ESCALATION: [BLOCKED | NEEDS_DECISION | UNCERTAINTY]
+Task: [task]
+Problem: [problem]
+Required: [what you need]
+```
+
+Common escalation triggers:
+
+- Plan references files that do not exist in codebase
+- Cannot determine review scope from context
+- Conflicting project documentation
+- Need user clarification on project-specific standards
+
+---
+
+<verification_checkpoint>
+STOP before producing output. Verify each item:
+
+- [ ] I read README.md and relevant project docs (or confirmed they don't exist)
+- [ ] For each RULE 0 finding: I named the specific unrecoverable consequence
+- [ ] For each RULE 0 finding: I used open verification questions (not yes/no)
+- [ ] For each MUST finding: I verified via dual-path reasoning
+- [ ] For each MUST finding: I used correct category name
+- [ ] For each RULE 1 finding: I cited the exact project standard violated
+- [ ] For each RULE 2 finding: I confirmed project docs don't explicitly permit it
+- [ ] For each finding: Suggested Fix passes actionability check
+- [ ] Findings contain only quality issues, not style preferences
+- [ ] Findings are ordered by severity (MUST, SHOULD, COULD), then by category
+- [ ] Finding headers use `[CATEGORY SEVERITY]` format (e.g. `[GOD_FUNCTION SHOULD]`)
+
+If any item fails verification, fix it before producing output.
+</verification_checkpoint>
+
+---
+
+## Review Contrasts: Correct vs Incorrect Decisions
+
+**INCORRECT — Style preference**
+Finding: "Function uses for-loop instead of list comprehension"
+Why wrong: Not covered by RULE 0, 1, or 2 unless project docs mandate comprehensions.
+
+**CORRECT — Not flagged after doc check**
+Considered: Long handler function in pipeline module
+Process: README allows monolithic pipeline steps → Not flagged
+
+**INCORRECT — Vague finding**
+Finding: "Potential issue with error handling somewhere"
+Why wrong: No location, no failure mode, not actionable.
+
+**CORRECT — RULE 0 with specifics**
+Finding: `[LLM_COMPREHENSION_RISK MUST]: Silent data loss in save path`
+Location: file:line
+Failure Mode: Caller reports success but data not persisted; unrecoverable
+Fix: Raise explicit error with original exception context
+
+**CORRECT — Accepted risk not re-flagged**
+Planning Context lists "race condition accepted for v1 with monitoring"
+Process: Found in Known Risks → Not flagged; note in NOT_FLAGGED

--- a/.cursor/agents/code-reviewer.md
+++ b/.cursor/agents/code-reviewer.md
@@ -71,7 +71,7 @@ these standards before flagging violations.
 
 **This repo — check before flagging RULE 1 issues:**
 
-- Conventional commits (`feat:`, `fix:`, `test:`, `ci:`, etc.) — see `.cursor/skills/pr-creator/SKILL.md`
+- Conventional commits (`feat:`, `fix:`, `test:`, `ci:`, etc.) — see `.cursor/agents/pr-creator.md`
 - Pre-commit: ruff lint/format, mypy (`--ignore-missing-imports`)
 - CI (`checks.yaml`): unittest + commitlint only; no full dependency install
 - Config files: `youtube_config.yaml`, `reddit_config.yaml`, `config.py`
@@ -142,7 +142,7 @@ You have full read access. 10+ file reads in one call is normal and encouraged.
   - [ ] Note "Constraints & Assumptions" — review within these bounds
   - [ ] Note "Decision Log" — accept these decisions as given
 - [ ] What project-specific constraints apply?
-- [ ] Read `.cursor/skills/pr-creator/SKILL.md` if reviewing commits or PRs
+- [ ] Read `.cursor/agents/pr-creator.md` if reviewing commits or PRs
  </discovery_checklist>
 
 <handle_missing_documentation>

--- a/.cursor/agents/pr-creator.md
+++ b/.cursor/agents/pr-creator.md
@@ -1,15 +1,22 @@
 ---
 name: pr-creator
 description: >-
-  Create GitHub pull requests with conventional commit messages and titles
-  (feat, fix, docs, ci, test). Use when creating a PR, opening a pull request,
-  preparing a branch for review, or when the user asks for commitlint-compliant
-  commits and PR titles.
+  Creates GitHub pull requests with conventional commits and commitlint-compliant
+  titles. Use proactively when preparing a branch for review, opening a PR,
+  splitting commits by type, or validating commit messages before push.
+model: inherit
 ---
 
-# PR Creator
+You create GitHub pull requests where every commit passes commitlint
+(`@commitlint/config-conventional`) and the PR title uses the same type prefix.
 
-Create PRs where every commit passes commitlint (`@commitlint/config-conventional`) and the PR title uses the same type prefix.
+When invoked:
+
+1. Inspect the branch (status, diff, log vs main)
+2. Plan focused conventional commits by type
+3. Validate with commitlint and unit tests
+4. Push and open the PR with `gh pr create`
+5. Watch CI until checks pass
 
 ## Conventional commit format
 
@@ -25,7 +32,7 @@ Create PRs where every commit passes commitlint (`@commitlint/config-conventiona
 |------|---------|
 | `feat` | New features or user-facing behavior |
 | `fix` | Bug fixes |
-| `docs` | Documentation and skills only |
+| `docs` | Documentation and agent configs only |
 | `test` | Tests only |
 | `ci` | GitHub Actions, commitlint, pre-commit CI |
 | `refactor` | Code changes without behavior change |
@@ -34,8 +41,9 @@ Create PRs where every commit passes commitlint (`@commitlint/config-conventiona
 ### Rules
 
 - Subject: imperative mood, lowercase, no trailing period, max ~72 chars
-- Scope: optional, lowercase (`shorts`, `youtube`, `workflow`)
+- Scope: optional, lowercase (`shorts`, `youtube`, `reddit`, `workflow`)
 - Header max length: 100 characters (commitlint default)
+- Body lines: max 100 characters
 
 ### Examples
 
@@ -43,7 +51,7 @@ Create PRs where every commit passes commitlint (`@commitlint/config-conventiona
 feat(shorts): add vertical pipeline with multi-part splitting
 test: add unit tests for segment splitting
 ci: add checks workflow with commitlint
-docs: add pr-creator skill for conventional commits
+docs: add pr-creator subagent for conventional commits
 fix(youtube): append Shorts hashtag to upload description
 ```
 
@@ -113,6 +121,8 @@ EOF
 )"
 ```
 
+Return the PR URL when done.
+
 ### 6. Verify CI
 
 ```bash
@@ -128,9 +138,9 @@ User-facing behavior change?     → feat
 Bug fix?                         → fix
 Only tests added/changed?        → test
 Only .github/workflows or lint?  → ci
-Only README/docs/skills?         → docs
+Only README/docs/agents?         → docs
 Refactor without behavior change?→ refactor
-Deps, config, housekeeping?    → chore
+Deps, config, housekeeping?      → chore
 ```
 
 When a branch mixes types, use the **most significant** type for the PR title (usually `feat` or `fix`).
@@ -148,3 +158,12 @@ When a branch mixes types, use the **most significant** type for the PR title (u
 - CI validates all commits in a PR via `wagoid/commitlint-github-action@v6`
 - Lint/format/typecheck run locally via pre-commit, not GitHub Actions
 - Python tests: `python -m unittest discover -s tests`
+- Config files: `youtube_config.yaml`, `reddit_config.yaml`, `config.py`
+
+## Git safety
+
+- Never update git config
+- Never force-push to main/master
+- Never skip hooks unless the user explicitly requests it
+- Only commit when the user asks or as part of this PR workflow
+- Do not push unless the user has asked or the workflow requires it for PR creation

--- a/.github/workflows/fetch-reddit-content.yaml
+++ b/.github/workflows/fetch-reddit-content.yaml
@@ -2,7 +2,7 @@ name: Reddit Video Editor
 
 on:
   schedule:
-    - cron: '0 5 * * *' # 10pm PST (05:00 UTC)
+    - cron: '30 1 * * *' # 5:30pm PST (01:30 UTC)
 
 jobs:
   run-main:

--- a/config.py
+++ b/config.py
@@ -3,9 +3,16 @@ from pathlib import Path
 import yaml
 
 CONFIG_PATH = Path("youtube_config.yaml")
+REDDIT_CONFIG_PATH = Path("reddit_config.yaml")
 
 
 def load_config() -> dict:
     """Load pipeline configuration from youtube_config.yaml."""
     with CONFIG_PATH.open("r") as f:
+        return yaml.safe_load(f) or {}
+
+
+def load_reddit_config() -> dict:
+    """Load subreddit sources from reddit_config.yaml."""
+    with REDDIT_CONFIG_PATH.open("r") as f:
         return yaml.safe_load(f) or {}

--- a/fetch_content.py
+++ b/fetch_content.py
@@ -3,7 +3,9 @@ import os
 import praw
 from dotenv import load_dotenv
 
+from config import load_reddit_config
 from logger import logger
+from reddit_sources import parse_subreddit_sources
 
 logger = logger
 
@@ -21,21 +23,27 @@ def create_password_flow_with_praw() -> praw.Reddit:
 
 
 def fetch_submissions(reddit: praw.Reddit) -> list[praw.models.Submission]:
-    """
-    Fetch the top daily submission from the AITAH subreddit.
-    """
-    list_of_submissions = []
-    for submission in reddit.subreddit("AITAH").top(time_filter="day", limit=1):
-        list_of_submissions.append(submission)
+    """Fetch top posts from each configured subreddit source."""
+    sources = parse_subreddit_sources(load_reddit_config())
+    submissions: list[praw.models.Submission] = []
 
-    if list_of_submissions:
-        logger.info("Reddit client created successfully with PRAW.")
+    for source in sources:
+        fetched = 0
+        for submission in reddit.subreddit(source.name).top(time_filter=source.time_filter, limit=source.limit):
+            submissions.append(submission)
+            fetched += 1
+        logger.info(
+            f"Fetched {fetched} submission(s) from r/{source.name} "
+            f"(time_filter={source.time_filter}, limit={source.limit})."
+        )
 
-    return list_of_submissions
+    if submissions:
+        logger.info(f"Fetched {len(submissions)} total submission(s) from {len(sources)} subreddit(s).")
+
+    return submissions
 
 
 if __name__ == "__main__":
-    # Example usage
     reddit = create_password_flow_with_praw()
     submissions = fetch_submissions(reddit)
-    logger.info(f"Fetched {len(submissions)} submission(s) from AITAH subreddit.")
+    logger.info(f"Fetched {len(submissions)} submission(s) from configured subreddits.")

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ def main() -> None:
     job_start_str = job_start.strftime("%Y-%m-%dT%H:%M:%SZ")
 
     submissions = fetch_content.fetch_submissions(fetch_content.create_password_flow_with_praw())
-    submissions = submissions[:1]  # Limit to the first submission for simplicity
     os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 
     for submission in submissions:

--- a/reddit_config.yaml
+++ b/reddit_config.yaml
@@ -1,8 +1,10 @@
 defaults:
   time_filter: day
-  limit: 1
+  limit: 1 # top posts to fetch per subreddit when limit is not set on the entry
   enabled: true
 
 subreddits:
   - name: AITAH
+    limit: 1
   - name: AmIOverreacting
+    limit: 1

--- a/reddit_config.yaml
+++ b/reddit_config.yaml
@@ -1,0 +1,8 @@
+defaults:
+  time_filter: day
+  limit: 1
+  enabled: true
+
+subreddits:
+  - name: AITAH
+  - name: AmIOverreacting

--- a/reddit_sources.py
+++ b/reddit_sources.py
@@ -21,11 +21,14 @@ def parse_subreddit_sources(config: dict) -> list[SubredditSource]:
             entry = {"name": entry}
         if not entry.get("enabled", default_enabled):
             continue
+        limit = entry.get("limit", default_limit)
+        if not isinstance(limit, int) or limit < 1:
+            raise ValueError(f"Subreddit {entry['name']!r} limit must be a positive integer, got {limit!r}")
         sources.append(
             SubredditSource(
                 name=entry["name"],
                 time_filter=entry.get("time_filter", default_time_filter),
-                limit=entry.get("limit", default_limit),
+                limit=limit,
             )
         )
 

--- a/reddit_sources.py
+++ b/reddit_sources.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SubredditSource:
+    name: str
+    time_filter: str
+    limit: int
+
+
+def parse_subreddit_sources(config: dict) -> list[SubredditSource]:
+    """Expand reddit_config.yaml entries into fetch settings."""
+    defaults = config.get("defaults", {})
+    default_time_filter = defaults.get("time_filter", "day")
+    default_limit = defaults.get("limit", 1)
+    default_enabled = defaults.get("enabled", True)
+
+    sources: list[SubredditSource] = []
+    for entry in config.get("subreddits", []):
+        if isinstance(entry, str):
+            entry = {"name": entry}
+        if not entry.get("enabled", default_enabled):
+            continue
+        sources.append(
+            SubredditSource(
+                name=entry["name"],
+                time_filter=entry.get("time_filter", default_time_filter),
+                limit=entry.get("limit", default_limit),
+            )
+        )
+
+    return sources

--- a/tests/test_reddit_config.py
+++ b/tests/test_reddit_config.py
@@ -41,3 +41,21 @@ class TestRedditConfig(unittest.TestCase):
         self.assertEqual(source.name, "AITAH")
         self.assertEqual(source.time_filter, "day")
         self.assertEqual(source.limit, 1)
+
+    def test_per_subreddit_limit_override(self) -> None:
+        config = {
+            "defaults": {"limit": 1},
+            "subreddits": [
+                {"name": "AITAH", "limit": 3},
+                {"name": "AmIOverreacting", "limit": 2},
+            ],
+        }
+        sources = parse_subreddit_sources(config)
+
+        self.assertEqual([(source.name, source.limit) for source in sources], [("AITAH", 3), ("AmIOverreacting", 2)])
+
+    def test_rejects_invalid_limit(self) -> None:
+        config = {"subreddits": [{"name": "AITAH", "limit": 0}]}
+
+        with self.assertRaises(ValueError):
+            parse_subreddit_sources(config)

--- a/tests/test_reddit_config.py
+++ b/tests/test_reddit_config.py
@@ -1,0 +1,43 @@
+import unittest
+
+from config import load_reddit_config
+from reddit_sources import parse_subreddit_sources
+
+
+class TestRedditConfig(unittest.TestCase):
+    def test_loads_configured_subreddits(self) -> None:
+        sources = parse_subreddit_sources(load_reddit_config())
+        names = [source.name for source in sources]
+
+        self.assertEqual(names, ["AITAH", "AmIOverreacting"])
+
+    def test_applies_defaults(self) -> None:
+        config = {
+            "defaults": {"time_filter": "week", "limit": 2, "enabled": True},
+            "subreddits": [{"name": "testsubreddit"}],
+        }
+        source = parse_subreddit_sources(config)[0]
+
+        self.assertEqual(source.name, "testsubreddit")
+        self.assertEqual(source.time_filter, "week")
+        self.assertEqual(source.limit, 2)
+
+    def test_skips_disabled_subreddits(self) -> None:
+        config = {
+            "defaults": {"enabled": True},
+            "subreddits": [
+                {"name": "enabled_sub"},
+                {"name": "disabled_sub", "enabled": False},
+            ],
+        }
+        names = [source.name for source in parse_subreddit_sources(config)]
+
+        self.assertEqual(names, ["enabled_sub"])
+
+    def test_supports_string_subreddit_entries(self) -> None:
+        config = {"subreddits": ["AITAH"]}
+        source = parse_subreddit_sources(config)[0]
+
+        self.assertEqual(source.name, "AITAH")
+        self.assertEqual(source.time_filter, "day")
+        self.assertEqual(source.limit, 1)


### PR DESCRIPTION
## Summary
- Add `reddit_config.yaml` to configure multiple subreddit sources with shared defaults
- Fetch top daily posts from each enabled subreddit (AITAH and AmIOverreacting)
- Process every fetched submission through the existing Shorts pipeline

## Test plan
- [x] `./scripts/validate-commits.sh main HEAD`
- [x] `python -m unittest discover -s tests`
- [x] CI checks pass on this PR
- [x] Manual run confirms posts are fetched from both subreddits

## Config example

Add or edit entries in `reddit_config.yaml`:

```yaml
subreddits:
  - name: AITAH
  - name: AmIOverreacting
    limit: 2
    enabled: true
```


Made with [Cursor](https://cursor.com)