### PR TITLE
fix(ci): install openai-whisper without pip build isolation

### DIFF
--- a/.github/workflows/fetch-reddit-content.yaml
+++ b/.github/workflows/fetch-reddit-content.yaml
@@ -19,8 +19,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --no-build-isolation -r requirements.txt
 
       - name: Install ffmpeg
         run: |


### PR DESCRIPTION
## Summary
- Pre-install `setuptools` and `wheel` before installing Python dependencies in the Reddit Video Editor workflow.
- Use `pip install --no-build-isolation` so `openai-whisper` can build from source without failing on `ModuleNotFoundError: No module named 'pkg_resources'`.

## Context
The workflow has been failing at the **Install dependencies** step because `openai-whisper==20240930` ships as an sdist and its `setup.py` imports `pkg_resources`, which is unavailable in pip's PEP 517 build isolation environment on Python 3.12.

## Test plan
- [ ] Merge PR
- [ ] Manually trigger the **Reddit Video Editor** workflow on `main`
- [ ] Confirm the **Install dependencies** step completes successfully


Made with [Cursor](https://cursor.com)