### PR TITLE
feat(subtitles): add horizontal padding to prevent edge clipping on phones

### DIFF
--- a/configs/youtube_config.yaml
+++ b/configs/youtube_config.yaml
@@ -19,6 +19,9 @@ shorts:
   # Distance in pixels from the bottom of the frame to the bottom of the subtitle block.
   # Keeps subtitles clear of YouTube Shorts UI buttons (~25% from bottom = ~480px on 1920px).
   subtitle_bottom_margin: 320
+  # Total horizontal padding in pixels (split evenly left + right).
+  # Prevents subtitles from reaching the screen edge on phones.
+  subtitle_horizontal_padding: 160
   add_hashtag: true               # append #Shorts to the upload description
   add_subreddit_hashtag: true     # append #SubredditName to the video title
 

--- a/highlighted_subtitles.py
+++ b/highlighted_subtitles.py
@@ -135,7 +135,9 @@ def render_highlighted_text(
         line_text = " ".join(line)
         bbox = measure_draw.textbbox((0, 0), line_text, font=font, stroke_width=STROKE_WIDTH)
         line_height = bbox[3] - bbox[1]
-        line_width = bbox[2] - bbox[0]
+        # Add WORD_EXTRA_GAP for each inter-word gap so the centering x matches
+        # what the rendering loop actually draws (which uses extra gap per word pair).
+        line_width = bbox[2] - bbox[0] + WORD_EXTRA_GAP * max(0, len(line) - 1)
         line_metrics.append((line, line_width, line_height))
         total_height += line_height
 

--- a/highlighted_subtitles.py
+++ b/highlighted_subtitles.py
@@ -183,10 +183,11 @@ def create_highlighted_subtitles_clip(
     duration: float,
     video_width: int,
     font_size: int,
+    horizontal_padding: int = 160,
 ) -> VideoClip:
     """Build a subtitle clip that highlights the active spoken word in light green,
     with a pop (scale-in) animation on each newly highlighted word."""
-    max_text_width = video_width - 80
+    max_text_width = video_width - horizontal_padding
     segment_words_list = [(segment, segment_words(segment)) for segment in part_segments]
 
     # Cache: (segment_index, highlight_index | None) → (image, highlighted_word_bbox)

--- a/videoeditor.py
+++ b/videoeditor.py
@@ -91,6 +91,7 @@ def _render_part(
     subtitle_font_size: int,
     subtitle_position: str,
     subtitle_bottom_margin: int,
+    subtitle_horizontal_padding: int,
     fps: int,
     all_cues: list[SoundCue] | None = None,
     sfx_config: dict | None = None,
@@ -112,6 +113,7 @@ def _render_part(
         duration=duration,
         video_width=clip.w,
         font_size=subtitle_font_size,
+        horizontal_padding=subtitle_horizontal_padding,
     )
     clip = clip.with_audio(part_audio)
     pos = _subtitle_position(clip, subtitles_clip, subtitle_position, subtitle_bottom_margin)
@@ -133,6 +135,7 @@ def create_videos(submission) -> list[tuple[str, int, int]]:
     subtitle_font_size = shorts.get("subtitle_font_size", 42)
     subtitle_position = shorts.get("subtitle_position", "lower_third")
     subtitle_bottom_margin = shorts.get("subtitle_bottom_margin", 320)
+    subtitle_horizontal_padding = shorts.get("subtitle_horizontal_padding", 160)
 
     output_folder = "output"
     os.makedirs(output_folder, exist_ok=True)
@@ -177,6 +180,7 @@ def create_videos(submission) -> list[tuple[str, int, int]]:
             subtitle_font_size=subtitle_font_size,
             subtitle_position=subtitle_position,
             subtitle_bottom_margin=subtitle_bottom_margin,
+            subtitle_horizontal_padding=subtitle_horizontal_padding,
             fps=fps,
             all_cues=all_cues,
             sfx_config=sfx_config,


### PR DESCRIPTION
## Summary

- Subtitles were rendering with only 40px per side of horizontal padding on a 1080px frame, causing them to run to the screen edge on iPhone
- Introduces `subtitle_horizontal_padding` in `configs/youtube_config.yaml` (default **160px** = 80px per side)
- Threads the value through `videoeditor.py` → `highlighted_subtitles.py`, replacing the previous hardcoded `80`
- Adjust `subtitle_horizontal_padding` in the yaml anytime to tune spacing without touching code

## Test plan

- [ ] Generate a video locally and verify subtitles have visible breathing room on both sides
- [ ] Check on an iPhone that text no longer reaches the edge

Made with [Cursor](https://cursor.com)