### PR TITLE
feat: TikTok-style subtitles — 3-4 words per group, 72px font

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyYAML
+          pip install PyYAML Pillow
 
       - name: Run Python tests
         run: python -m unittest discover -s tests -v

--- a/.github/workflows/fetch-reddit-content.yaml
+++ b/.github/workflows/fetch-reddit-content.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyYAML
+          pip install PyYAML Pillow
 
       - name: Run tests
         run: python -m unittest discover -s tests -v

--- a/configs/youtube_config.yaml
+++ b/configs/youtube_config.yaml
@@ -14,14 +14,18 @@ shorts:
   max_duration_seconds: 180
   long_content_strategy: split  # split | trim
   crop_mode: center  # center-crop landscape footage to 9:16
-  subtitle_font_size: 42
+  subtitle_font_size: 72
   subtitle_position: lower_third  # center | lower_third
   # Distance in pixels from the bottom of the frame to the bottom of the subtitle block.
   # Keeps subtitles clear of YouTube Shorts UI buttons (~25% from bottom = ~480px on 1920px).
   subtitle_bottom_margin: 320
   # Total horizontal padding in pixels (split evenly left + right).
   # Prevents subtitles from reaching the screen edge on phones.
-  subtitle_horizontal_padding: 160
+  subtitle_horizontal_padding: 120
+  # Max words shown on screen at once (TikTok-style caption chunking).
+  # Whisper segments are rechunked into groups of this size so the viewer
+  # always sees a small, easy-to-follow burst of words.
+  subtitle_max_words_per_group: 4
   add_hashtag: true               # append #Shorts to the upload description
   add_subreddit_hashtag: true     # append #SubredditName to the video title
 

--- a/docs/view-to-swipe-ratio.md
+++ b/docs/view-to-swipe-ratio.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft / Proposal
 **Author:** _TBD_
-**Last updated:** 2026-06-18
+**Last updated:** 2026-06-19
 
 ---
 
@@ -27,12 +27,12 @@ Shorts data consistently shows ~60–70% of viewers who leave do so in the **fir
 |--------|----------------|---------------|
 | Post selection quality | `configs/reddit_config.yaml`, `fetch_content.py`, `reddit_sources.py` | Uses Reddit `top` ranking (upvote-validated) — considered solved |
 | Opening hook (title card) | `videoeditor.py` | Not implemented — starts straight into narration |
-| Subtitle readability | `highlighted_subtitles.py`, `youtube_config.yaml` | Padding + green highlight + pop animation |
+| Subtitle readability | `highlighted_subtitles.py`, `youtube_config.yaml` | TikTok-style: 4 words on screen, 72px neon green highlight + pop animation |
 | TTS voice/speed | `youtube_config.yaml` → `tts.py` | `en-US-GuyNeural`, +10% speed |
 | Tags/discoverability | `youtube.py`, `youtube_config.yaml` | Tiered tag system in place |
 | Video title | `youtube.py` | Post title + subreddit hashtag |
 | Background footage | `videoeditor.py` | Single hardcoded `assets/video/input2.mp4` |
-| Sound effects | `sound_effects.py`, `configs/sfx_config.yaml` | Keyword/profanity-triggered SFX mixed into TTS; no intro sound |
+| Sound effects | `sound_effects.py`, `configs/sfx_config.yaml` | Keyword/profanity-triggered SFX; Emergency Radio Alert intro + background music |
 
 ---
 
@@ -41,6 +41,29 @@ Shorts data consistently shows ~60–70% of viewers who leave do so in the **fir
 Two changes are proposed for the first iteration, plus a set of follow-ups.
 
 > **Note on content quality:** We deliberately do *not* add an upvote/length filter. Reddit's `top` ranking already surfaces community-validated, high-upvote posts, so an extra score filter would be redundant. Content selection is considered solved by the existing `top(time_filter=...)` fetch.
+
+### 3.0 TikTok-Style Subtitle Chunking (Implemented — High Impact)
+
+**Problem:** Full Whisper segments (5–15 words) appeared on screen at once. Viewers had to read ahead while listening, which increases cognitive load and swipe-away rate in the first few seconds.
+
+**Implemented design:** Rechunk all aligned words into groups of 4 (configurable). Only one group is visible at a time; the currently spoken word is highlighted in neon green (`#39FF14`) with a pop animation. Font size increased from 42px → 72px so words are readable at a glance on mobile.
+
+```yaml
+shorts:
+  subtitle_font_size: 72
+  subtitle_max_words_per_group: 4   # 3–5 recommended for Shorts retention
+  subtitle_horizontal_padding: 120
+  subtitle_bottom_margin: 320
+```
+
+**Touch points:**
+- `highlighted_subtitles.py` — `_rechunk_words()`, `create_highlighted_subtitles_clip(max_words_per_group=...)`
+- `configs/youtube_config.yaml` — knobs above
+- `tests/test_highlighted_subtitles.py` — unit tests for chunking and rendering
+
+**Why it works:** Short-form platforms (TikTok, Reels) train viewers to expect small caption bursts. Showing 3–4 words at a time keeps eyes on the screen and reduces the "wall of text" effect that triggers swipes.
+
+---
 
 ### 3.1 Title Card Hook Overlay (Proposal — High Impact)
 
@@ -72,44 +95,36 @@ shorts:
 
 ---
 
-### 3.2 Intro Sound Effect (Proposal — Medium Impact)
+### 3.2 Intro Sound Effect (Implemented — Medium Impact)
 
-**Problem:** The audio currently opens cold on the narration. A short, punchy intro sound under the title card adds an audio hook that signals *"a story is starting"* and pairs with the visual in 3.1.
+**Problem:** The audio previously opened cold on the narration. A short, punchy intro sound signals *"a story is starting"* and pairs with the visual hook.
 
-**Proposed design:** Reuse the existing SFX engine rather than building anything new. The pipeline already mixes timestamped `SoundCue`s into the TTS track via `mix_sound_effects` (`sound_effects.py`). We add an always-on intro cue at `t=0` for part 1 (not a keyword trigger — it always fires), gated by config.
+**Implemented design:** Reuse the existing SFX engine. An always-on intro cue at `t=0` for part 1 fires via `build_intro_cues()` in `sound_effects.py`.
 
-**Sound assets (YouTube Audio Library):** Two intro stingers are already in `assets/sfx/`:
+**Sound asset (YouTube Audio Library):**
 
 | File | Character |
 |------|-----------|
-| `Reverberating Slam.mp3` | Heavy, dramatic impact — good for conflict/drama posts |
-| `Crash Metal Sweetener Distant.mp3` | Metallic crash with distance — slightly lighter, still attention-grabbing |
-
-**Randomization:** Pick one file at random per video (part 1 only). This keeps the opening from feeling identical across every upload while still landing a strong hook. Over time, retention data in YouTube Studio can show whether one sound outperforms the other.
-
-- `random.choice(intro_files)` at render time in `videoeditor.py` (or a small helper in `sound_effects.py`).
-- Same volume for both so the mix is consistent regardless of which clip plays.
-- Ideally timed with the title-card window (3.1) so audio and visual hooks land together.
+| `Emergency Radio Alert.mp3` | Urgent EAS-style alert — strong attention grab at t=0 |
 
 ```yaml
 # configs/sfx_config.yaml
 intro:
   enabled: true
   files:
-    - assets/sfx/Reverberating Slam.mp3
-    - assets/sfx/Crash Metal Sweetener Distant.mp3
-  volume: 0.6        # keep it under the narration so it doesn't startle
-  parts: first_only  # first_only | all
+    - assets/sfx/Emergency Radio Alert.mp3
+  volume: 1.0
+  parts: first_only
 ```
 
 **Touch points:**
-- `configs/sfx_config.yaml` — `intro` section with `files` list (not a single path).
-- `sound_effects.py` / `videoeditor.py` — random pick from `intro.files`, build `SoundCue(effect="intro", start_time=0.0, ...)`, pass into existing mix step.
-- `assets/sfx/README.md` — document the two intro filenames.
+- `configs/sfx_config.yaml` — `intro` section
+- `sound_effects.py` / `videoeditor.py` — `build_intro_cues()`, mixed via existing `mix_sound_effects` step
+- `assets/sfx/README.md` — documents the intro filename
 
 **Open questions:**
-- Volume level — loud enough to register, quiet enough not to clip the first narrated word? Start at `0.6` and tune after local preview.
-- First part only, or every part? Default `first_only`.
+- Volume level — tune after local preview if the alert clips the first narrated word.
+- First part only, or every part? Currently `first_only`.
 
 ---
 
@@ -137,9 +152,9 @@ Read the retention graph per video: a sharp drop at 0–3s means the hook needs 
 
 ## 6. Rollout Plan
 
-1. Land this design doc; agree on defaults and open questions.
-2. Implement 3.1 (title card) behind `title_card_enabled`.
-3. Implement 3.2 (intro sound) behind `intro.enabled`, ideally timed with the title card.
+1. ~~Land subtitle chunking (3.0)~~ — shipped on `feat/bigger-subtitles`.
+2. ~~Land intro sound (3.2)~~ — shipped on `feat/cursor-skills`.
+3. Land title card (3.1) behind `title_card_enabled`.
 4. Run with `DEBUG=True` locally; review output videos manually.
 5. Enable in production config; monitor retention for 1–2 weeks vs. baseline.
 6. Decide on follow-ups based on metrics.

--- a/highlighted_subtitles.py
+++ b/highlighted_subtitles.py
@@ -1,6 +1,11 @@
-import numpy as np
-from moviepy import VideoClip
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from PIL import Image, ImageDraw, ImageFont
+
+if TYPE_CHECKING:
+    from moviepy import VideoClip
 
 FONT_PATH = "assets/fonts/Poppins-Medium.ttf"
 HIGHLIGHT_COLOR = "#39FF14"
@@ -187,60 +192,93 @@ def render_highlighted_text(
     return image, highlighted_word_bbox
 
 
+def _rechunk_words(
+    segment_words_list: list[tuple[dict, list[dict]]],
+    max_words_per_group: int,
+) -> list[list[dict]]:
+    """Flatten all Whisper word dicts and rechunk into fixed-size groups.
+
+    Each group is shown on screen simultaneously, replacing the full-segment
+    display. Smaller groups (3–4 words) create the TikTok-style caption effect
+    that keeps viewers engaged.
+    """
+    flat = [w for _, words in segment_words_list for w in words]
+    groups: list[list[dict]] = []
+    for i in range(0, len(flat), max_words_per_group):
+        chunk = flat[i : i + max_words_per_group]
+        if chunk:
+            groups.append(chunk)
+    return groups
+
+
 def create_highlighted_subtitles_clip(
     part_segments: list[dict],
     part_start: float,
     duration: float,
     video_width: int,
     font_size: int,
-    horizontal_padding: int = 160,
+    horizontal_padding: int = 120,
+    max_words_per_group: int = 4,
 ) -> tuple[VideoClip, int]:
-    """Build a subtitle clip that highlights the active spoken word in light green,
-    with a pop (scale-in) animation on each newly highlighted word."""
+    """Build a subtitle clip that highlights the active spoken word in neon green,
+    with a pop (scale-in) animation on each newly highlighted word.
+
+    Words are rechunked into groups of `max_words_per_group` (default 4) so
+    only a small burst of words is visible at once — the TikTok-style caption
+    format proven to maximise view-to-swipe ratio on short-form video.
+    """
+    import numpy as np
+    from moviepy import VideoClip
+
     max_text_width = video_width - horizontal_padding
     segment_words_list = [(segment, segment_words(segment)) for segment in part_segments]
 
-    # Cache: (segment_index, highlight_index | None) → (image, highlighted_word_bbox)
+    # Rechunk words into fixed-size groups for TikTok-style display.
+    word_groups: list[list[dict]] = _rechunk_words(segment_words_list, max_words_per_group)
+
+    # Cache: (group_index, highlight_index | None) → (image, highlighted_word_bbox)
     render_cache: dict[tuple[int, int | None], tuple[Image.Image, tuple[int, int, int, int] | None]] = {}
-    for segment_index, (_, words) in enumerate(segment_words_list):
-        word_text = [word_info["word"] for word_info in words]
-        render_cache[(segment_index, None)] = render_highlighted_text(word_text, None, font_size, max_text_width)
-        for highlight_index in range(len(words)):
-            render_cache[(segment_index, highlight_index)] = render_highlighted_text(
+    for group_index, group in enumerate(word_groups):
+        word_text = [w["word"] for w in group]
+        render_cache[(group_index, None)] = render_highlighted_text(word_text, None, font_size, max_text_width)
+        for highlight_index in range(len(group)):
+            render_cache[(group_index, highlight_index)] = render_highlighted_text(
                 word_text, highlight_index, font_size, max_text_width
             )
 
-    # Word timing lookup: (segment_index, word_index) → (start, end) relative to part_start
+    # Word timing lookup: (group_index, word_index) → (start, end) relative to part_start
     word_timings: dict[tuple[int, int], tuple[float, float]] = {}
-    for segment_index, (_, words) in enumerate(segment_words_list):
-        for word_index, word_info in enumerate(words):
-            word_timings[(segment_index, word_index)] = (
+    for group_index, group in enumerate(word_groups):
+        for word_index, word_info in enumerate(group):
+            word_timings[(group_index, word_index)] = (
                 float(word_info["start"]) - part_start,
                 float(word_info["end"]) - part_start,
             )
 
     def active_state(t: float) -> tuple[int, int | None] | None:
-        for segment_index, (segment, words) in enumerate(segment_words_list):
-            start = float(segment["start"]) - part_start
-            end = float(segment["end"]) - part_start
-            if start <= t < end:
+        for group_index, group in enumerate(word_groups):
+            if not group:
+                continue
+            group_start = float(group[0]["start"]) - part_start
+            group_end = float(group[-1]["end"]) - part_start
+            if group_start <= t < group_end:
                 highlight_index = None
-                for index, word_info in enumerate(words):
+                for word_index, word_info in enumerate(group):
                     word_start = float(word_info["start"]) - part_start
                     word_end = float(word_info["end"]) - part_start
                     if word_start <= t < word_end:
-                        highlight_index = index
+                        highlight_index = word_index
                         break
-                return segment_index, highlight_index
+                return group_index, highlight_index
         return None
 
     def _animated_image(state: tuple[int, int | None], t: float) -> Image.Image:
         """Return the subtitle image with the pop animation applied for time t."""
         image, word_bbox = render_cache[state]
-        segment_index, highlight_index = state
+        group_index, highlight_index = state
 
         if highlight_index is not None and word_bbox is not None:
-            timing = word_timings.get((segment_index, highlight_index))
+            timing = word_timings.get((group_index, highlight_index))
             if timing:
                 word_start, word_end = timing
                 word_dur = word_end - word_start

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,3 +12,6 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(shorts["height"], 1920)
         self.assertEqual(shorts["max_duration_seconds"], 180)
         self.assertEqual(shorts["long_content_strategy"], "split")
+        self.assertEqual(shorts["subtitle_font_size"], 72)
+        self.assertEqual(shorts["subtitle_horizontal_padding"], 120)
+        self.assertEqual(shorts["subtitle_max_words_per_group"], 4)

--- a/tests/test_highlighted_subtitles.py
+++ b/tests/test_highlighted_subtitles.py
@@ -1,0 +1,100 @@
+import unittest
+
+from highlighted_subtitles import (
+    POP_PADDING,
+    _rechunk_words,
+    render_highlighted_text,
+    segment_words,
+)
+
+
+def _word(text: str, start: float, end: float) -> dict:
+    return {"word": text, "start": start, "end": end}
+
+
+def _segment(text: str, start: float, end: float, words: list[dict] | None = None) -> dict:
+    return {"text": text, "start": start, "end": end, "words": words}
+
+
+class TestRechunkWords(unittest.TestCase):
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(_rechunk_words([], 4), [])
+
+    def test_fewer_words_than_group_size(self) -> None:
+        segment_words_list = [(_segment("hello world", 0.0, 1.0), [_word("hello", 0.0, 0.5), _word("world", 0.5, 1.0)])]
+        groups = _rechunk_words(segment_words_list, 4)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual([w["word"] for w in groups[0]], ["hello", "world"])
+
+    def test_exact_multiple_of_group_size(self) -> None:
+        words = [_word(f"w{i}", float(i), float(i + 1)) for i in range(8)]
+        segment_words_list = [(_segment(" ".join(w["word"] for w in words), 0.0, 8.0), words)]
+        groups = _rechunk_words(segment_words_list, 4)
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(len(groups[0]), 4)
+        self.assertEqual(len(groups[1]), 4)
+
+    def test_remainder_creates_final_short_group(self) -> None:
+        words = [_word(f"w{i}", float(i), float(i + 1)) for i in range(5)]
+        segment_words_list = [(_segment("five words", 0.0, 5.0), words)]
+        groups = _rechunk_words(segment_words_list, 4)
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(len(groups[0]), 4)
+        self.assertEqual(len(groups[1]), 1)
+
+    def test_flattens_across_multiple_segments(self) -> None:
+        segment_words_list = [
+            (_segment("one two", 0.0, 2.0), [_word("one", 0.0, 1.0), _word("two", 1.0, 2.0)]),
+            (
+                _segment("three four five", 2.0, 5.0),
+                [_word("three", 2.0, 3.0), _word("four", 3.0, 4.0), _word("five", 4.0, 5.0)],
+            ),
+        ]
+        groups = _rechunk_words(segment_words_list, 4)
+        self.assertEqual(len(groups), 2)
+        self.assertEqual([w["word"] for w in groups[0]], ["one", "two", "three", "four"])
+        self.assertEqual([w["word"] for w in groups[1]], ["five"])
+
+    def test_preserves_word_timing_dicts(self) -> None:
+        original = _word("hello", 1.0, 1.5)
+        segment_words_list = [(_segment("hello", 1.0, 1.5), [original])]
+        groups = _rechunk_words(segment_words_list, 4)
+        self.assertIs(groups[0][0], original)
+
+
+class TestSegmentWords(unittest.TestCase):
+    def test_normalizes_whisper_words(self) -> None:
+        segment = _segment(
+            "Hello World",
+            0.0,
+            1.0,
+            [{"word": " Hello ", "start": 0.0, "end": 0.5}, {"word": " World ", "start": 0.5, "end": 1.0}],
+        )
+        words = segment_words(segment)
+        self.assertEqual([w["word"] for w in words], ["hello", "world"])
+
+    def test_falls_back_to_segment_text_when_no_word_timestamps(self) -> None:
+        segment = _segment("alpha beta gamma", 0.0, 3.0, None)
+        words = segment_words(segment)
+        self.assertEqual([w["word"] for w in words], ["alpha", "beta", "gamma"])
+        self.assertAlmostEqual(words[0]["start"], 0.0)
+        self.assertAlmostEqual(words[-1]["end"], 3.0)
+
+
+class TestRenderHighlightedText(unittest.TestCase):
+    def test_canvas_includes_pop_padding(self) -> None:
+        image, _ = render_highlighted_text(["hello", "world"], None, font_size=72, max_width=920)
+        # Without POP_PADDING the canvas would be shorter; padding adds 2 * POP_PADDING px.
+        self.assertGreaterEqual(image.height, 2 * POP_PADDING)
+
+    def test_highlighted_word_gets_bbox(self) -> None:
+        _, bbox = render_highlighted_text(["one", "two", "three"], highlight_index=1, font_size=72, max_width=920)
+        self.assertIsNotNone(bbox)
+        x, y, w, h = bbox  # type: ignore[misc]
+        self.assertGreater(w, 0)
+        self.assertGreater(h, 0)
+        self.assertGreaterEqual(y, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/videoeditor.py
+++ b/videoeditor.py
@@ -93,6 +93,7 @@ def _render_part(
     subtitle_position: str,
     subtitle_bottom_margin: int,
     subtitle_horizontal_padding: int,
+    subtitle_max_words_per_group: int,
     fps: int,
     all_cues: list[SoundCue] | None = None,
     sfx_config: dict | None = None,
@@ -123,6 +124,7 @@ def _render_part(
         video_width=clip.w,
         font_size=subtitle_font_size,
         horizontal_padding=subtitle_horizontal_padding,
+        max_words_per_group=subtitle_max_words_per_group,
     )
     clip = clip.with_audio(part_audio)
     pos = _subtitle_position(clip, max_subtitle_h, subtitle_position, subtitle_bottom_margin)
@@ -141,10 +143,11 @@ def create_videos(submission) -> list[tuple[str, int, int]]:
     fps = shorts.get("fps", 30)
     max_duration = shorts.get("max_duration_seconds", 180)
     crop_mode = shorts.get("crop_mode", "center")
-    subtitle_font_size = shorts.get("subtitle_font_size", 42)
+    subtitle_font_size = shorts.get("subtitle_font_size", 72)
     subtitle_position = shorts.get("subtitle_position", "lower_third")
     subtitle_bottom_margin = shorts.get("subtitle_bottom_margin", 320)
-    subtitle_horizontal_padding = shorts.get("subtitle_horizontal_padding", 160)
+    subtitle_horizontal_padding = shorts.get("subtitle_horizontal_padding", 120)
+    subtitle_max_words_per_group = shorts.get("subtitle_max_words_per_group", 4)
 
     output_folder = "output"
     os.makedirs(output_folder, exist_ok=True)
@@ -243,6 +246,7 @@ def create_videos(submission) -> list[tuple[str, int, int]]:
             subtitle_position=subtitle_position,
             subtitle_bottom_margin=subtitle_bottom_margin,
             subtitle_horizontal_padding=subtitle_horizontal_padding,
+            subtitle_max_words_per_group=subtitle_max_words_per_group,
             fps=fps,
             all_cues=part_cues or None,
             sfx_config=sfx_config,


### PR DESCRIPTION
## Summary

- **Word-group chunking**: Whisper output is now rechunked into groups of 4 words (configurable) so only a small burst of text is visible at once — the TikTok/Reels caption style proven to keep viewers watching instead of swiping
- **72px font**: Up from 42px so words are immediately readable at a glance without the viewer needing to scan a full sentence
- **Tighter horizontal padding**: 160px → 120px to give larger text more room while still keeping it clear of screen edges

## How it works

Previously, each Whisper segment (5–15 words) was rendered all at once. Now `_rechunk_words()` flattens all word dicts across segments and slices them into N-word groups. Each group is shown on screen simultaneously, with the currently-spoken word highlighted in neon green. When the group finishes, the next group snaps in.

## Config knobs (in `configs/youtube_config.yaml`)

```yaml
subtitle_font_size: 72          # px — increase for more impact
subtitle_max_words_per_group: 4 # words visible at once (3–5 recommended)
subtitle_horizontal_padding: 120
```

## Test plan

- [ ] Run `python3 main.py` — confirm only 3-4 words appear at a time, cycling with each group
- [ ] Check the neon green highlight moves word by word within each group
- [ ] Confirm bottom line is not clipped (POP_PADDING fix still active)

Made with [Cursor](https://cursor.com)