### PR TITLE
fix(ci): wire OTLP secrets and silence MoviePy render logs

### DIFF
--- a/.github/workflows/fetch-reddit-content.yaml
+++ b/.github/workflows/fetch-reddit-content.yaml
@@ -65,5 +65,8 @@ jobs:
           YT_CLIENT_ID: ${{ secrets.YT_CLIENT_ID }}
           YT_CLIENT_SECRET: ${{ secrets.YT_CLIENT_SECRET }}
           YT_REFRESH_TOKEN: ${{ secrets.YT_REFRESH_TOKEN }}
+          OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
+          OTEL_EXPORTER_OTLP_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
+          OTEL_SERVICE_NAME: reddit-tts-video
         run: |
           python main.py

--- a/videoeditor.py
+++ b/videoeditor.py
@@ -5,7 +5,7 @@ import stable_whisper
 from moviepy import AudioFileClip, CompositeVideoClip, ImageClip, VideoFileClip, concatenate_audioclips, vfx
 from moviepy.video.fx.Loop import Loop
 
-from config import load_config, load_sfx_config
+from config import DEBUG, load_config, load_sfx_config
 from highlighted_subtitles import create_highlighted_subtitles_clip
 from logger import logger
 from parts import split_segments
@@ -230,7 +230,11 @@ def _render_part(
         layers.append(card_clip)
     layers.append(subtitles_clip.with_position(pos))
     final_video = CompositeVideoClip(layers)
-    final_video.write_videofile(output_path, fps=fps)
+    final_video.write_videofile(
+        output_path,
+        fps=fps,
+        logger="bar" if DEBUG else None,
+    )
 
 
 def create_videos(submission) -> list[tuple[str, int, int]]:


### PR DESCRIPTION
## Summary
- Pass `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and `OTEL_SERVICE_NAME` into the scheduled `run-main` job
- Fixes the warning `metrics.otel.enabled is true but no OTLP endpoint is configured` when Grafana secrets already exist in GitHub Actions
- Silence MoviePy `frame_index` tqdm spam in production by passing `logger=None` to `write_videofile` when `DEBUG=False`

## Test plan
- [ ] Merge and trigger **Reddit Video Editor** via workflow_dispatch
- [ ] Confirm logs no longer show the OTLP endpoint warning
- [ ] Confirm logs no longer flood with `frame_index` progress lines during render
- [ ] Confirm Grafana receives metrics/traces from the run